### PR TITLE
Adding store state helpers

### DIFF
--- a/dist/Biff.js
+++ b/dist/Biff.js
@@ -172,6 +172,8 @@ var Store = (function () {
 
     var self = this;
     this.callback = callback;
+    this.pending = false;
+    this.errors = [];
     if ("production" !== "production" && methods.callback) {
       throw new Error("Invariant Violation: \"callback\" is a reserved name and cannot be used as a method name.");
     }
@@ -211,6 +213,66 @@ var Store = (function () {
 
       value: function getDispatchToken() {
         return this.dispatcherID;
+      },
+      writable: true,
+      configurable: true
+    },
+    getPending: {
+
+      /**
+       * Returns a Store's "pending" state
+       */
+
+      value: function getPending() {
+        return this.pending;
+      },
+      writable: true,
+      configurable: true
+    },
+    setPending: {
+
+      /**
+       * Sets a Store's "pending" state
+       */
+
+      value: function setPending(pending) {
+        this.pending = pending;
+      },
+      writable: true,
+      configurable: true
+    },
+    getErrors: {
+
+      /**
+       * Returns a Store's "errors" array
+       */
+
+      value: function getErrors() {
+        return this.errors;
+      },
+      writable: true,
+      configurable: true
+    },
+    setError: {
+
+      /**
+       * Adds an error to a Store's "errors" array
+       */
+
+      value: function setError(error) {
+        this.errors.push(error);
+      },
+      writable: true,
+      configurable: true
+    },
+    clearErrors: {
+
+      /**
+       * Clears a Store's "errors" array
+       */
+
+      value: function clearErrors(error) {
+        this.errors.splice(0, this.errors.length);
       },
       writable: true,
       configurable: true

--- a/dist/Biff.js
+++ b/dist/Biff.js
@@ -229,13 +229,13 @@ var Store = (function () {
       writable: true,
       configurable: true
     },
-    setPending: {
+    _setPending: {
 
       /**
        * Sets a Store's "pending" state
        */
 
-      value: function setPending(pending) {
+      value: function _setPending(pending) {
         this.pending = pending;
       },
       writable: true,
@@ -253,25 +253,25 @@ var Store = (function () {
       writable: true,
       configurable: true
     },
-    setError: {
+    _setError: {
 
       /**
        * Adds an error to a Store's "errors" array
        */
 
-      value: function setError(error) {
+      value: function _setError(error) {
         this.errors.push(error);
       },
       writable: true,
       configurable: true
     },
-    clearErrors: {
+    _clearErrors: {
 
       /**
        * Clears a Store's "errors" array
        */
 
-      value: function clearErrors(error) {
+      value: function _clearErrors(error) {
         this.errors.splice(0, this.errors.length);
       },
       writable: true,

--- a/dist/Biff.js
+++ b/dist/Biff.js
@@ -172,8 +172,8 @@ var Store = (function () {
 
     var self = this;
     this.callback = callback;
-    this.__pending = false;
-    this.__errors = [];
+    this._pending = false;
+    this._errors = [];
     if ("production" !== "production" && methods.callback) {
       throw new Error("Invariant Violation: \"callback\" is a reserved name and cannot be used as a method name.");
     }
@@ -224,7 +224,7 @@ var Store = (function () {
        */
 
       value: function getPending() {
-        return this.__pending;
+        return this._pending;
       },
       writable: true,
       configurable: true
@@ -236,7 +236,7 @@ var Store = (function () {
        */
 
       value: function _setPending(pending) {
-        this.__pending = pending;
+        this._pending = pending;
       },
       writable: true,
       configurable: true
@@ -248,7 +248,7 @@ var Store = (function () {
        */
 
       value: function getErrors() {
-        return this.__errors;
+        return this._errors;
       },
       writable: true,
       configurable: true
@@ -260,7 +260,7 @@ var Store = (function () {
        */
 
       value: function _setError(error) {
-        this.__errors.push(error);
+        this._errors.push(error);
       },
       writable: true,
       configurable: true
@@ -272,7 +272,7 @@ var Store = (function () {
        */
 
       value: function _clearErrors(error) {
-        this.__errors.splice(0, this.errors.length);
+        this._errors.splice(0, this.errors.length);
       },
       writable: true,
       configurable: true

--- a/dist/Biff.js
+++ b/dist/Biff.js
@@ -172,8 +172,8 @@ var Store = (function () {
 
     var self = this;
     this.callback = callback;
-    this.pending = false;
-    this.errors = [];
+    this.__pending = false;
+    this.__errors = [];
     if ("production" !== "production" && methods.callback) {
       throw new Error("Invariant Violation: \"callback\" is a reserved name and cannot be used as a method name.");
     }
@@ -224,7 +224,7 @@ var Store = (function () {
        */
 
       value: function getPending() {
-        return this.pending;
+        return this.__pending;
       },
       writable: true,
       configurable: true
@@ -236,7 +236,7 @@ var Store = (function () {
        */
 
       value: function _setPending(pending) {
-        this.pending = pending;
+        this.__pending = pending;
       },
       writable: true,
       configurable: true
@@ -248,7 +248,7 @@ var Store = (function () {
        */
 
       value: function getErrors() {
-        return this.errors;
+        return this.__errors;
       },
       writable: true,
       configurable: true
@@ -260,7 +260,7 @@ var Store = (function () {
        */
 
       value: function _setError(error) {
-        this.errors.push(error);
+        this.__errors.push(error);
       },
       writable: true,
       configurable: true
@@ -272,7 +272,7 @@ var Store = (function () {
        */
 
       value: function _clearErrors(error) {
-        this.errors.splice(0, this.errors.length);
+        this.__errors.splice(0, this.errors.length);
       },
       writable: true,
       configurable: true

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -85,13 +85,13 @@ var Store = (function () {
       writable: true,
       configurable: true
     },
-    setPending: {
+    _setPending: {
 
       /**
        * Sets a Store's "pending" state
        */
 
-      value: function setPending(pending) {
+      value: function _setPending(pending) {
         this.pending = pending;
       },
       writable: true,
@@ -109,25 +109,25 @@ var Store = (function () {
       writable: true,
       configurable: true
     },
-    setError: {
+    _setError: {
 
       /**
        * Adds an error to a Store's "errors" array
        */
 
-      value: function setError(error) {
+      value: function _setError(error) {
         this.errors.push(error);
       },
       writable: true,
       configurable: true
     },
-    clearErrors: {
+    _clearErrors: {
 
       /**
        * Clears a Store's "errors" array
        */
 
-      value: function clearErrors(error) {
+      value: function _clearErrors(error) {
         this.errors.splice(0, this.errors.length);
       },
       writable: true,

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -28,8 +28,8 @@ var Store = (function () {
 
     var self = this;
     this.callback = callback;
-    this.pending = false;
-    this.errors = [];
+    this.__pending = false;
+    this.__errors = [];
     if (process.env.NODE_ENV !== "production" && methods.callback) {
       throw new Error("Invariant Violation: \"callback\" is a reserved name and cannot be used as a method name.");
     }
@@ -80,7 +80,7 @@ var Store = (function () {
        */
 
       value: function getPending() {
-        return this.pending;
+        return this.__pending;
       },
       writable: true,
       configurable: true
@@ -92,7 +92,7 @@ var Store = (function () {
        */
 
       value: function _setPending(pending) {
-        this.pending = pending;
+        this.__pending = pending;
       },
       writable: true,
       configurable: true
@@ -104,7 +104,7 @@ var Store = (function () {
        */
 
       value: function getErrors() {
-        return this.errors;
+        return this.__errors;
       },
       writable: true,
       configurable: true
@@ -116,7 +116,7 @@ var Store = (function () {
        */
 
       value: function _setError(error) {
-        this.errors.push(error);
+        this.__errors.push(error);
       },
       writable: true,
       configurable: true
@@ -128,7 +128,7 @@ var Store = (function () {
        */
 
       value: function _clearErrors(error) {
-        this.errors.splice(0, this.errors.length);
+        this.__errors.splice(0, this.errors.length);
       },
       writable: true,
       configurable: true

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -28,6 +28,8 @@ var Store = (function () {
 
     var self = this;
     this.callback = callback;
+    this.pending = false;
+    this.errors = [];
     if (process.env.NODE_ENV !== "production" && methods.callback) {
       throw new Error("Invariant Violation: \"callback\" is a reserved name and cannot be used as a method name.");
     }
@@ -67,6 +69,66 @@ var Store = (function () {
 
       value: function getDispatchToken() {
         return this.dispatcherID;
+      },
+      writable: true,
+      configurable: true
+    },
+    getPending: {
+
+      /**
+       * Returns a Store's "pending" state
+       */
+
+      value: function getPending() {
+        return this.pending;
+      },
+      writable: true,
+      configurable: true
+    },
+    setPending: {
+
+      /**
+       * Sets a Store's "pending" state
+       */
+
+      value: function setPending(pending) {
+        this.pending = pending;
+      },
+      writable: true,
+      configurable: true
+    },
+    getErrors: {
+
+      /**
+       * Returns a Store's "errors" array
+       */
+
+      value: function getErrors() {
+        return this.errors;
+      },
+      writable: true,
+      configurable: true
+    },
+    setError: {
+
+      /**
+       * Adds an error to a Store's "errors" array
+       */
+
+      value: function setError(error) {
+        this.errors.push(error);
+      },
+      writable: true,
+      configurable: true
+    },
+    clearErrors: {
+
+      /**
+       * Clears a Store's "errors" array
+       */
+
+      value: function clearErrors(error) {
+        this.errors.splice(0, this.errors.length);
       },
       writable: true,
       configurable: true

--- a/lib/Store.js
+++ b/lib/Store.js
@@ -28,8 +28,8 @@ var Store = (function () {
 
     var self = this;
     this.callback = callback;
-    this.__pending = false;
-    this.__errors = [];
+    this._pending = false;
+    this._errors = [];
     if (process.env.NODE_ENV !== "production" && methods.callback) {
       throw new Error("Invariant Violation: \"callback\" is a reserved name and cannot be used as a method name.");
     }
@@ -80,7 +80,7 @@ var Store = (function () {
        */
 
       value: function getPending() {
-        return this.__pending;
+        return this._pending;
       },
       writable: true,
       configurable: true
@@ -92,7 +92,7 @@ var Store = (function () {
        */
 
       value: function _setPending(pending) {
-        this.__pending = pending;
+        this._pending = pending;
       },
       writable: true,
       configurable: true
@@ -104,7 +104,7 @@ var Store = (function () {
        */
 
       value: function getErrors() {
-        return this.__errors;
+        return this._errors;
       },
       writable: true,
       configurable: true
@@ -116,7 +116,7 @@ var Store = (function () {
        */
 
       value: function _setError(error) {
-        this.__errors.push(error);
+        this._errors.push(error);
       },
       writable: true,
       configurable: true
@@ -128,7 +128,7 @@ var Store = (function () {
        */
 
       value: function _clearErrors(error) {
-        this.__errors.splice(0, this.errors.length);
+        this._errors.splice(0, this.errors.length);
       },
       writable: true,
       configurable: true

--- a/src/Store.js
+++ b/src/Store.js
@@ -20,8 +20,8 @@ class Store {
   constructor(methods, callback) {
     var self = this;
     this.callback = callback;
-    this.pending = false;
-    this.errors = [];
+    this.__pending = false;
+    this.__errors = [];
     if (process.env.NODE_ENV !== 'production' && methods.callback) {
       throw new Error('Invariant Violation: "callback" is a reserved name and cannot be used as a method name.');
     }
@@ -57,35 +57,35 @@ class Store {
    * Returns a Store's "pending" state
    */
   getPending() {
-    return this.pending;
+    return this.__pending;
   }
 
   /**
    * Sets a Store's "pending" state
    */
   _setPending(pending) {
-    this.pending = pending;
+    this.__pending = pending;
   }
 
   /**
    * Returns a Store's "errors" array
    */
   getErrors() {
-    return this.errors;
+    return this.__errors;
   }
 
   /**
    * Adds an error to a Store's "errors" array
    */
   _setError(error) {
-    this.errors.push(error);
+    this.__errors.push(error);
   }
 
   /**
    * Clears a Store's "errors" array
    */
   _clearErrors(error) {
-    this.errors.splice(0, this.errors.length);
+    this.__errors.splice(0, this.errors.length);
   }
 
   /**

--- a/src/Store.js
+++ b/src/Store.js
@@ -20,8 +20,8 @@ class Store {
   constructor(methods, callback) {
     var self = this;
     this.callback = callback;
-    this.__pending = false;
-    this.__errors = [];
+    this._pending = false;
+    this._errors = [];
     if (process.env.NODE_ENV !== 'production' && methods.callback) {
       throw new Error('Invariant Violation: "callback" is a reserved name and cannot be used as a method name.');
     }
@@ -57,35 +57,35 @@ class Store {
    * Returns a Store's "pending" state
    */
   getPending() {
-    return this.__pending;
+    return this._pending;
   }
 
   /**
    * Sets a Store's "pending" state
    */
   _setPending(pending) {
-    this.__pending = pending;
+    this._pending = pending;
   }
 
   /**
    * Returns a Store's "errors" array
    */
   getErrors() {
-    return this.__errors;
+    return this._errors;
   }
 
   /**
    * Adds an error to a Store's "errors" array
    */
   _setError(error) {
-    this.__errors.push(error);
+    this._errors.push(error);
   }
 
   /**
    * Clears a Store's "errors" array
    */
   _clearErrors(error) {
-    this.__errors.splice(0, this.errors.length);
+    this._errors.splice(0, this.errors.length);
   }
 
   /**

--- a/src/Store.js
+++ b/src/Store.js
@@ -20,6 +20,8 @@ class Store {
   constructor(methods, callback) {
     var self = this;
     this.callback = callback;
+    this.pending = false;
+    this.errors = [];
     if (process.env.NODE_ENV !== 'production' && methods.callback) {
       throw new Error('Invariant Violation: "callback" is a reserved name and cannot be used as a method name.');
     }
@@ -49,6 +51,46 @@ class Store {
    */
   getDispatchToken() {
     return this.dispatcherID;
+  }
+
+  /**
+   * Returns a Store's "pending" state
+   */
+
+  getPending() {
+    return this.pending;
+  }
+
+  /**
+   * Sets a Store's "pending" state
+   */
+
+  setPending(pending) {
+    this.pending = pending;
+  }
+
+  /**
+   * Returns a Store's "errors" array
+   */
+
+  getErrors() {
+    return this.errors;
+  }
+
+  /**
+   * Adds an error to a Store's "errors" array
+   */
+
+  setError(error) {
+    this.errors.push(error);
+  }
+
+  /**
+   * Clears a Store's "errors" array
+   */
+
+  clearErrors(error) {
+    this.errors.splice(0, this.errors.length);
   }
 
   /**

--- a/src/Store.js
+++ b/src/Store.js
@@ -56,7 +56,6 @@ class Store {
   /**
    * Returns a Store's "pending" state
    */
-
   getPending() {
     return this.pending;
   }
@@ -64,15 +63,13 @@ class Store {
   /**
    * Sets a Store's "pending" state
    */
-
-  setPending(pending) {
+  _setPending(pending) {
     this.pending = pending;
   }
 
   /**
    * Returns a Store's "errors" array
    */
-
   getErrors() {
     return this.errors;
   }
@@ -80,16 +77,14 @@ class Store {
   /**
    * Adds an error to a Store's "errors" array
    */
-
-  setError(error) {
+  _setError(error) {
     this.errors.push(error);
   }
 
   /**
    * Clears a Store's "errors" array
    */
-
-  clearErrors(error) {
+  _clearErrors(error) {
     this.errors.splice(0, this.errors.length);
   }
 


### PR DESCRIPTION
@eastridge Added the following store state helpers:

``` js
Store.getPending() // Returns store's pending state
Store.setPending(arg) // Sets store's pending state
Store.getErrors() // Returns store's errors array
Store.setError(arg) // Pushes an error onto the store's errors array
Store.clearErrors() // Clears the store's errors array
```
